### PR TITLE
[#2] Add two archetype properties for rest project dependencies

### DIFF
--- a/gatein-rest-resource-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/gatein-rest-resource-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="gatein-rest-resource-sources"
+<archetype-descriptor
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
+    name="gatein-rest-resource-sources"
     xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <requiredProperties>
+    <requiredProperty key="javaxWsRsVersion">
+      <defaultValue>1.0</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="exoWsRestCoreVersion">
+      <defaultValue>2.3.7-GA</defaultValue>
+    </requiredProperty>
+  </requiredProperties>
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/main/java</directory>

--- a/gatein-rest-resource-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/gatein-rest-resource-archetype/src/main/resources/archetype-resources/pom.xml
@@ -16,6 +16,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
+    <javax.ws.rs.version>${javaxWsRsVersion}</javax.ws.rs.version>
+    <exo.ws.rest.core.version>${exoWsRestCoreVersion}</exo.ws.rest.core.version>
     <jarBuildPath>${project.build.directory}</jarBuildPath>
   </properties>
 
@@ -23,13 +25,13 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
-      <version>1.0</version>
+      <version>${javax.ws.rs.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.ws</groupId>
       <artifactId>exo.ws.rest.core</artifactId>
-      <version>2.3.7-GA</version>
+      <version>${exo.ws.rest.core.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/gatein-rest-resource-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/gatein-rest-resource-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,3 +3,5 @@ package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
+javaxWsRsVersion=1.0
+exoWsRestCoreVersion=2.3.7-GA


### PR DESCRIPTION
Two archetype properties with default values where added to hold gatein rest resource module dependencies:
- `javaxWsRsVersion`
- `exoWsRestCoreVersion`
